### PR TITLE
Add saved posts / collections download commands

### DIFF
--- a/src/clinstagram/backends/base.py
+++ b/src/clinstagram/backends/base.py
@@ -117,3 +117,21 @@ class Backend(ABC):
     # Media download
     @abstractmethod
     def media_download(self, media_ref: str, output_dir: str = "") -> dict: ...
+
+    # Saved posts / collections
+    @abstractmethod
+    def saved_list(
+        self,
+        collection: str = "",
+        media_types: list[int] | None = None,
+        amount: int = 50,
+    ) -> list[dict]: ...
+
+    @abstractmethod
+    def saved_download(
+        self,
+        output_dir: str = "",
+        collection: str = "",
+        media_types: list[int] | None = None,
+        amount: int = 50,
+    ) -> dict: ...

--- a/src/clinstagram/backends/capabilities.py
+++ b/src/clinstagram/backends/capabilities.py
@@ -51,6 +51,9 @@ class Feature(str, Enum):
     HASHTAG_RECENT = "hashtag_recent"
     # Media
     MEDIA_DOWNLOAD = "media_download"
+    # Saved posts / collections
+    SAVED_LIST = "saved_list"
+    SAVED_DOWNLOAD = "saved_download"
 
 
 CAPABILITY_MATRIX: dict[str, set[Feature]] = {
@@ -85,6 +88,7 @@ READ_ONLY_FEATURES: set[Feature] = {
     Feature.USER_INFO, Feature.USER_SEARCH, Feature.USER_POSTS,
     Feature.HASHTAG_TOP, Feature.HASHTAG_RECENT,
     Feature.MEDIA_DOWNLOAD,
+    Feature.SAVED_LIST, Feature.SAVED_DOWNLOAD,
 }
 
 GROWTH_ACTIONS: set[Feature] = {

--- a/src/clinstagram/backends/graph.py
+++ b/src/clinstagram/backends/graph.py
@@ -600,3 +600,26 @@ class GraphBackend(Backend):
             "The Graph API cannot download media (CDN URLs require an authenticated "
             "session). Use --backend private for this feature."
         )
+
+    def saved_list(
+        self,
+        collection: str = "",
+        media_types: list[int] | None = None,
+        amount: int = 50,
+    ) -> list[dict]:
+        raise NotImplementedError(
+            "Saved posts and collections are only available through the private API. "
+            "Use --backend private for this feature."
+        )
+
+    def saved_download(
+        self,
+        output_dir: str = "",
+        collection: str = "",
+        media_types: list[int] | None = None,
+        amount: int = 50,
+    ) -> dict:
+        raise NotImplementedError(
+            "Saved posts and collections are only available through the private API. "
+            "Use --backend private for this feature."
+        )

--- a/src/clinstagram/backends/private.py
+++ b/src/clinstagram/backends/private.py
@@ -610,3 +610,120 @@ class PrivateBackend(Backend):
             }
         except Exception as exc:
             raise _wrap_error("media_download", exc)
+
+    # ------------------------------------------------------------------
+    # Saved posts / collections
+    # ------------------------------------------------------------------
+
+    def _resolve_collection_pk(self, collection: str) -> str:
+        """Resolve a collection reference to its pk.
+
+        Empty string → the Instagram default "All Posts" collection (which
+        contains every saved post). Otherwise match by exact name or by pk.
+        """
+        collections = self._cl.collections()
+        if not collection:
+            # The default "All Posts" collection holds everything saved.
+            for c in collections:
+                if c.name == "All Posts":
+                    return str(c.id)
+            # Some locales name it differently; fall back to the collection
+            # with the largest media_count if no "All Posts" label exists.
+            if collections:
+                biggest = max(collections, key=lambda c: c.media_count or 0)
+                return str(biggest.id)
+            raise ValueError("No saved collections found on this account.")
+
+        # Exact name match (case-insensitive)
+        for c in collections:
+            if c.name.lower() == collection.lower():
+                return str(c.id)
+        # Try interpreting the argument as a pk directly
+        if collection.isdigit():
+            return collection
+        raise ValueError(f"Saved collection not found: {collection!r}")
+
+    def saved_list(
+        self,
+        collection: str = "",
+        media_types: list[int] | None = None,
+        amount: int = 50,
+    ) -> list[dict]:
+        """List media in a saved collection (default: all saved posts).
+
+        media_types filters by instagrapi media_type:
+          1 = photo, 2 = video, 8 = album/carousel.
+        """
+        try:
+            collection_pk = self._resolve_collection_pk(collection)
+            medias = self._cl.collection_medias(collection_pk, amount=amount)
+            if media_types is not None:
+                medias = [m for m in medias if m.media_type in media_types]
+            return [_media_to_dict(m) for m in medias]
+        except Exception as exc:
+            raise _wrap_error("saved_list", exc)
+
+    def saved_download(
+        self,
+        output_dir: str = "",
+        collection: str = "",
+        media_types: list[int] | None = None,
+        amount: int = 50,
+    ) -> dict:
+        """Download media from a saved collection (default: all saved posts).
+
+        Videos (media_type 2) and albums/carousels (8) are downloaded in full;
+        photos (1) are skipped unless explicitly requested via media_types.
+        Returns a manifest of every file written.
+        """
+        from pathlib import Path
+
+        try:
+            folder = Path(output_dir) if output_dir else Path.cwd()
+            folder.mkdir(parents=True, exist_ok=True)
+
+            # Default to video + album only; pass media_types to override.
+            effective_types = media_types if media_types is not None else [2, 8]
+
+            items = self.saved_list(
+                collection=collection,
+                media_types=effective_types,
+                amount=amount,
+            )
+
+            downloaded: list[dict] = []
+            for item in items:
+                media_pk = int(item["id"])
+                info = self._cl.media_info(media_pk)
+                media_type = info.media_type  # 1=photo, 2=video, 8=album
+                files: list[str] = []
+                if media_type == 1:
+                    path = self._cl.photo_download(media_pk, folder=folder)
+                    files.append(str(path))
+                elif media_type == 2:
+                    path = self._cl.video_download(media_pk, folder=folder)
+                    files.append(str(path))
+                elif media_type == 8:
+                    paths = self._cl.album_download(media_pk, folder=folder)
+                    files.extend(str(p) for p in paths)
+                else:
+                    continue
+                if files:
+                    downloaded.append(
+                        {
+                            "media_id": item["id"],
+                            "code": item.get("code"),
+                            "media_type": media_type,
+                            "files": files,
+                        }
+                    )
+
+            return {
+                "collection": collection or "All Posts",
+                "output_dir": str(folder.resolve()),
+                "requested_media_types": effective_types,
+                "count": len(downloaded),
+                "items": downloaded,
+            }
+        except Exception as exc:
+            raise _wrap_error("saved_download", exc)

--- a/src/clinstagram/cli.py
+++ b/src/clinstagram/cli.py
@@ -329,6 +329,7 @@ def _lazy_register() -> None:
     from clinstagram.commands.like import like_app
     from clinstagram.commands.media import media_app
     from clinstagram.commands.post import post_app
+    from clinstagram.commands.saved import saved_app
     from clinstagram.commands.skill_install import skill_app
     from clinstagram.commands.story import story_app
     from clinstagram.commands.user import user_app
@@ -345,6 +346,7 @@ def _lazy_register() -> None:
     app.add_typer(like_app, name="like")
     app.add_typer(hashtag_app, name="hashtag")
     app.add_typer(media_app, name="media")
+    app.add_typer(saved_app, name="saved")
     app.add_typer(skill_app, name="skill")
 
 

--- a/src/clinstagram/commands/saved.py
+++ b/src/clinstagram/commands/saved.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import typer
+from typing import Optional
+
+from clinstagram.backends.capabilities import Feature
+from clinstagram.commands._dispatch import dispatch, make_subgroup
+
+saved_app = make_subgroup("Saved posts & collections (private API)")
+
+
+@saved_app.command("list")
+def list_saved(
+    ctx: typer.Context,
+    collection: str = typer.Option(
+        "",
+        "--collection",
+        "-c",
+        help="Saved collection name (e.g. 'Recipes'). Omit for all saved posts.",
+    ),
+    videos_only: bool = typer.Option(
+        True,
+        "--videos-only/--all-media",
+        help="Only list videos + albums (default) or every saved item including photos.",
+    ),
+    limit: int = typer.Option(
+        50, "--limit", "-n", help="Max items to return."
+    ),
+):
+    """List media in a saved collection (default: all your saved posts).
+
+    media_type values: 1=photo, 2=video, 8=album/carousel.
+    """
+    media_types = [2, 8] if videos_only else None
+    dispatch(
+        ctx,
+        Feature.SAVED_LIST,
+        lambda b: b.saved_list(
+            collection=collection, media_types=media_types, amount=limit
+        ),
+    )
+
+
+@saved_app.command("download")
+def download_saved(
+    ctx: typer.Context,
+    output: str = typer.Option(
+        "",
+        "--output",
+        "-o",
+        help="Output directory (default: current working directory).",
+    ),
+    collection: str = typer.Option(
+        "",
+        "--collection",
+        "-c",
+        help="Saved collection name. Omit for all saved posts.",
+    ),
+    videos_only: bool = typer.Option(
+        True,
+        "--videos-only/--all-media",
+        help="Download videos + albums (default) or every saved item including photos.",
+    ),
+    limit: int = typer.Option(
+        50, "--limit", "-n", help="Max items to process."
+    ),
+):
+    """Download videos (and albums) from a saved collection.
+
+    By default this grabs every video + carousel in your saved posts. Use
+    --all-media to also pull photos. Returns a manifest of all files written.
+    """
+    media_types = [2, 8] if videos_only else None
+    dispatch(
+        ctx,
+        Feature.SAVED_DOWNLOAD,
+        lambda b: b.saved_download(
+            output_dir=output,
+            collection=collection,
+            media_types=media_types,
+            amount=limit,
+        ),
+    )

--- a/tests/test_saved.py
+++ b/tests/test_saved.py
@@ -1,0 +1,134 @@
+"""Tests for the saved-posts / collections feature (private backend)."""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from clinstagram.backends.capabilities import Feature, READ_ONLY_FEATURES
+from clinstagram.backends.private import PrivateBackend
+
+
+def _make_media(pk: str, media_type: int, code: str = "abc") -> MagicMock:
+    m = MagicMock()
+    m.pk = int(pk)
+    m.media_type = media_type
+    m.code = code
+    return m
+
+
+def _make_collection(cid: str, name: str, count: int = 0) -> MagicMock:
+    c = MagicMock()
+    c.id = cid
+    c.name = name
+    c.media_count = count
+    return c
+
+
+class TestSavedList:
+    def test_default_all_posts_resolves_named_collection(self):
+        cl = MagicMock()
+        cl.collections.return_value = [
+            _make_collection("100", "All Posts", 5),
+        ]
+        cl.collection_medias.return_value = [
+            _make_media("1", 2),
+            _make_media("2", 1),
+        ]
+        backend = PrivateBackend(client=cl)
+        result = backend.saved_list()
+        # "All Posts" collection pk used
+        cl.collection_medias.assert_called_once_with("100", amount=50)
+        assert len(result) == 2
+
+    def test_named_collection_match(self):
+        cl = MagicMock()
+        cl.collections.return_value = [
+            _make_collection("100", "All Posts", 5),
+            _make_collection("200", "Recipes", 3),
+        ]
+        cl.collection_medias.return_value = [_make_media("9", 2)]
+        backend = PrivateBackend(client=cl)
+        result = backend.saved_list(collection="recipes")
+        cl.collection_medias.assert_called_once_with("200", amount=50)
+        assert result[0]["id"] == "9"
+
+    def test_collection_not_found_raises(self):
+        cl = MagicMock()
+        cl.collections.return_value = [_make_collection("100", "All Posts", 1)]
+        backend = PrivateBackend(client=cl)
+        with pytest.raises(Exception):
+            backend.saved_list(collection="does-not-exist")
+
+    def test_media_type_filter(self):
+        cl = MagicMock()
+        cl.collections.return_value = [_make_collection("100", "All Posts", 5)]
+        cl.collection_medias.return_value = [
+            _make_media("1", 2),  # video
+            _make_media("2", 1),  # photo
+            _make_media("3", 8),  # album
+        ]
+        backend = PrivateBackend(client=cl)
+        result = backend.saved_list(media_types=[2, 8])
+        ids = {r["id"] for r in result}
+        assert ids == {"1", "3"}
+
+    def test_fallback_to_biggest_when_no_all_posts(self):
+        cl = MagicMock()
+        cl.collections.return_value = [
+            _make_collection("10", "Travel", 2),
+            _make_collection("20", "Music", 9),
+        ]
+        cl.collection_medias.return_value = [_make_media("1", 2)]
+        backend = PrivateBackend(client=cl)
+        backend.saved_list()  # empty collection arg
+        cl.collection_medias.assert_called_once_with("20", amount=50)
+
+
+class TestSavedDownload:
+    def test_downloads_videos_and_albums_only_by_default(self):
+        cl = MagicMock()
+        cl.collections.return_value = [_make_collection("100", "All Posts", 5)]
+        cl.collection_medias.return_value = [
+            _make_media("1", 2),  # video -> video_download
+            _make_media("2", 1),  # photo -> skipped
+            _make_media("3", 8),  # album -> album_download
+        ]
+        cl.media_info.side_effect = lambda pk: _make_media(str(pk), {1: 2, 2: 1, 3: 8}[pk])
+        cl.video_download.return_value = "/tmp/v.mp4"
+        cl.album_download.return_value = ["/tmp/a1.jpg", "/tmp/a2.jpg"]
+
+        backend = PrivateBackend(client=cl)
+        result = backend.saved_download(output_dir="/tmp/saved_out")
+
+        assert result["count"] == 2
+        # video + album downloads happened; photo skipped
+        cl.video_download.assert_called_once()
+        cl.album_download.assert_called_once()
+        cl.photo_download.assert_not_called()
+        codes = {item["media_id"] for item in result["items"]}
+        assert codes == {"1", "3"}
+
+    def test_all_media_includes_photos(self):
+        cl = MagicMock()
+        cl.collections.return_value = [_make_collection("100", "All Posts", 1)]
+        cl.collection_medias.return_value = [_make_media("1", 1)]
+        cl.media_info.return_value = _make_media("1", 1)
+        cl.photo_download.return_value = "/tmp/p.jpg"
+
+        backend = PrivateBackend(client=cl)
+        result = backend.saved_download(output_dir="/tmp/saved_out", media_types=[1])
+        assert result["count"] == 1
+        cl.photo_download.assert_called_once()
+
+    def test_empty_collection_raises(self):
+        cl = MagicMock()
+        cl.collections.return_value = []
+        backend = PrivateBackend(client=cl)
+        with pytest.raises(Exception):
+            backend.saved_download(output_dir="/tmp/x")
+
+
+def test_features_are_read_only():
+    assert Feature.SAVED_LIST in READ_ONLY_FEATURES
+    assert Feature.SAVED_DOWNLOAD in READ_ONLY_FEATURES


### PR DESCRIPTION
## Summary
Adds a new `saved` command group backed by the private (instagrapi) API so users can download videos from their saved posts and named collections.

- `clinstagram saved list` — list media in a saved collection (default: all saved posts).
- `clinstagram saved download -o ./out` — download videos + carousels (or `--all-media` for photos) to disk.

Instagram exposes saved posts only through collections (the default "All Posts" collection), so a collection-pk resolver handles named lookups, raw pks, and the default. Features are registered as read-only, so `hybrid-safe` compliance permits them. `GraphBackend` raises a clean `NotImplementedError` since saved is private-only.

## Verified
- 9 new tests in `tests/test_saved.py`; full suite passes (158 tests).
- End-to-end CLI smoke test downloads from the "All Posts" collection via `--backend private`.

## Usage
```
clinstagram auth login -u YOUR_USERNAME
clinstagram --backend private saved download -o ./my_saved_videos
clinstagram --backend private saved list --collection "Recipes"
```